### PR TITLE
Add Snackbar Alert

### DIFF
--- a/src/components/HomeDashboard.vue
+++ b/src/components/HomeDashboard.vue
@@ -115,7 +115,6 @@
         this.snackbar = val[1];
         this.snackbarText = val[0];
         this.snackbarColor = val[2];
-        console.log("test");
       },
     },
   };

--- a/src/components/HomeDashboard.vue
+++ b/src/components/HomeDashboard.vue
@@ -14,9 +14,10 @@
                 :lg="sections.length < 4 ? 6 : 3"
                 :md="6"
                 :sm="6"
-                :xs="12"
-              >
-                <SectionItem :section="section"></SectionItem>
+                :xs="12">
+                <SectionItem
+                  :section="section"
+                  @openSnackbarEvent="openSnackBar"></SectionItem>
               </v-col>
             </v-row>
           </v-container>
@@ -39,11 +40,28 @@
         </v-card>
       </v-col>
     </v-row>
+    <v-snackbar
+      v-model="snackbar"
+      :timeout="timeout"
+      color="darkBlue white--text">
+      {{ snackbarText }}
+
+      <template v-slot:action="{ attrs }">
+        <v-btn
+          color="white"
+          text
+          v-bind="attrs"
+          @click="snackbar = false"
+          class="font-weight-bold">
+          Close
+        </v-btn>
+      </template>
+    </v-snackbar>
   </v-container>
 </template>
 
 <script>
-import SectionItem from "./SectionItem.vue";
+  import SectionItem from "./SectionItem.vue";
 
   export default {
     name: "HomeDashboard",
@@ -85,7 +103,17 @@ import SectionItem from "./SectionItem.vue";
             sectionTerms: ["T1", "T2"],
           },
         ],
+        timeout: 2000,
+        snackbar: false,
+        snackbarText: "",
       };
+    },
+    methods: {
+      openSnackBar(val) {
+        this.snackbar = val[1];
+        this.snackbarText = val[0];
+        console.log("test");
+      },
     },
   };
 </script>

--- a/src/components/HomeDashboard.vue
+++ b/src/components/HomeDashboard.vue
@@ -41,9 +41,10 @@
       </v-col>
     </v-row>
     <v-snackbar
+      class="font-weight-bold"
       v-model="snackbar"
       :timeout="timeout"
-      color="darkBlue white--text">
+      :color="snackbarColor">
       {{ snackbarText }}
 
       <template v-slot:action="{ attrs }">
@@ -106,12 +107,14 @@
         timeout: 2000,
         snackbar: false,
         snackbarText: "",
+        snackbarColor: "darkBlue",
       };
     },
     methods: {
       openSnackBar(val) {
         this.snackbar = val[1];
         this.snackbarText = val[0];
+        this.snackbarColor = val[2];
         console.log("test");
       },
     },

--- a/src/components/SectionItem.vue
+++ b/src/components/SectionItem.vue
@@ -91,6 +91,7 @@
         </template>
         <SectionItemEdit
           @closeDialogEvent="closeEditDialog"
+          @openSnackbarEvent="openSnackBar"
           :section="section"></SectionItemEdit>
       </v-dialog>
 
@@ -106,6 +107,7 @@
         </template>
         <SectionItemDelete
           @closeDialogEvent="closeDeleteDialog"
+          @openSnackbarEvent="openSnackBar"
           :section="section"></SectionItemDelete>
       </v-dialog>
     </v-card-actions>
@@ -137,6 +139,11 @@
       },
       closeDeleteDialog(val) {
         this.deleteDialog = val;
+      },
+      openSnackBar(val) {
+        console.log(val[0]);
+
+        this.$emit("openSnackbarEvent", val);
       },
       createDOWString() {
         let ret = "";

--- a/src/components/SectionItemDelete.vue
+++ b/src/components/SectionItemDelete.vue
@@ -43,7 +43,7 @@
         this.$emit("closeDialogEvent", false);
       },
       openSnackbar(val) {
-        this.$emit("openSnackbarEvent", [val, true]);
+        this.$emit("openSnackbarEvent", [val, true, "lightRed"]);
       },
     },
   };

--- a/src/components/SectionItemDelete.vue
+++ b/src/components/SectionItemDelete.vue
@@ -20,7 +20,9 @@
         text
         class="font-weight-bold"
         color="darkerRed"
-        @click="closeDialog()">
+        @click="
+          closeDialog(), openSnackbar(section.sectionNumber + ' Deleted.')
+        ">
         Delete
       </v-btn>
       <v-spacer></v-spacer>
@@ -39,6 +41,9 @@
     methods: {
       closeDialog() {
         this.$emit("closeDialogEvent", false);
+      },
+      openSnackbar(val) {
+        this.$emit("openSnackbarEvent", [val, true]);
       },
     },
   };

--- a/src/components/SectionItemEdit.vue
+++ b/src/components/SectionItemEdit.vue
@@ -271,7 +271,7 @@
         text
         class="font-weight-bold"
         color="darkerGreen"
-        @click="closeDialog()"
+        @click="closeDialog(), openSnackbar(section.sectionNumber + ' Saved.')"
         >Save</v-btn
       >
     </v-card-actions>
@@ -336,6 +336,9 @@
     methods: {
       closeDialog() {
         this.$emit("closeDialogEvent", false);
+      },
+      openSnackbar(val) {
+        this.$emit("openSnackbarEvent", [val, true]);
       },
       parseDate(date) {
         if (!date) return null;

--- a/src/components/SectionItemEdit.vue
+++ b/src/components/SectionItemEdit.vue
@@ -338,7 +338,7 @@
         this.$emit("closeDialogEvent", false);
       },
       openSnackbar(val) {
-        this.$emit("openSnackbarEvent", [val, true]);
+        this.$emit("openSnackbarEvent", [val, true, "lightGreen"]);
       },
       parseDate(date) {
         if (!date) return null;


### PR DESCRIPTION
Adds a snack bar alert (small box that pops up on the bottom of the screen, otherwise known as a toast) for saving of edit and deletion of section item.

To test just follow either edit or delete all the way through.

@LoganDemaray316 I want you to add this for course edit and delete too. I can explain in more detail in person exactly how it works.